### PR TITLE
Rrajigar Mine level - Tarydium Shard +80 message fix

### DIFF
--- a/Unreal/SystemLocalized/ctt/Dig.ctt
+++ b/Unreal/SystemLocalized/ctt/Dig.ctt
@@ -75,3 +75,7 @@ Hint="Prem els botons vermells a la paret empenyent-los."
 Message="L'estat de font d'alimentació dos de camp de força és actiu."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Prem els botons vermells a la paret empenyent-los."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Heu recollit 80 Fragments de Taridi"

--- a/Unreal/SystemLocalized/det/Dig.det
+++ b/Unreal/SystemLocalized/det/Dig.det
@@ -78,4 +78,4 @@ Hint="Drücke auf die roten Knöpfe an der Wand, indem du gegen sie stößt."
 
 [StingerAmmo17]
 ; EN: PickupMessage="You picked up 80 Tarydium Shards"
-PickupMessage="40 Tarydiumsplitter erhalten"
+PickupMessage="80 Tarydiumsplitter erhalten"

--- a/Unreal/SystemLocalized/det/Dig.det
+++ b/Unreal/SystemLocalized/det/Dig.det
@@ -75,3 +75,7 @@ Hint="Drücke auf die roten Knöpfe an der Wand, indem du gegen sie stößt."
 Message="Kraftfeld-Energieversorgung Zwei, Status ist aktiv."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Drücke auf die roten Knöpfe an der Wand, indem du gegen sie stößt."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="40 Tarydiumsplitter erhalten"

--- a/Unreal/SystemLocalized/est/Dig.est
+++ b/Unreal/SystemLocalized/est/Dig.est
@@ -75,3 +75,7 @@ Hint="Pulsa los botones rojos del muro tocándolos."
 Message="Fuente de energía dos del Campo de Fuerza activa."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Pulsa los botones rojos del muro tocándolos."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Has recogido 80 Fragmentos de Taridio"

--- a/Unreal/SystemLocalized/frt/Dig.frt
+++ b/Unreal/SystemLocalized/frt/Dig.frt
@@ -75,3 +75,7 @@ Hint="Appuyez sur les boutons rouges au mur en les touchant."
 Message="La source d'énergie 2 du champ de force est active."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Appuyez sur les boutons rouges au mur en les touchant."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Vous avez ramassé 80 Éclats de Tarydium"

--- a/Unreal/SystemLocalized/int/Dig.int
+++ b/Unreal/SystemLocalized/int/Dig.int
@@ -52,3 +52,6 @@ Hint="Press the red buttons on the wall by bumping into them."
 [TranslatorEvent7]
 Message="Force Field power source two status is active."
 Hint="Press the red buttons on the wall by bumping into them."
+
+[StingerAmmo17]
+PickupMessage="You picked up 80 Tarydium Shards"

--- a/Unreal/SystemLocalized/itt/Dig.itt
+++ b/Unreal/SystemLocalized/itt/Dig.itt
@@ -75,3 +75,7 @@ Hint="Premi i pulsanti rossi sul muro andandoci contro."
 Message="Lo stato della seconda fonte d'energia del Campo di Forza è "attivo"."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Premi i pulsanti rossi sul muro andandoci contro."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Hai raccolto 80 schegge di Tarydium"

--- a/Unreal/SystemLocalized/nlt/Dig.nlt
+++ b/Unreal/SystemLocalized/nlt/Dig.nlt
@@ -75,3 +75,7 @@ Hint="Druk op de rode knoppen aan de muur door er tegenaan te botsen."
 Message="KrachtVeld stroombron twee status is actief."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Druk op de rode knoppen aan de muur door er tegenaan te botsen."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Je hebt 80 Tarydium-scherven"

--- a/Unreal/SystemLocalized/plt/Dig.plt
+++ b/Unreal/SystemLocalized/plt/Dig.plt
@@ -75,3 +75,7 @@ Hint="Podejdź do czerwonych przycisków przy ścianie, aby je włączyć."
 Message="Drugie źródło zasilania pola siłowego jest aktywne."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Podejdź do czerwonych przycisków przy ścianie, aby je włączyć."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Podnosisz 80 Odłamków Tarydu"

--- a/Unreal/SystemLocalized/ptt/Dig.ptt
+++ b/Unreal/SystemLocalized/ptt/Dig.ptt
@@ -75,3 +75,7 @@ Hint="Aperte os botões vermelhos na parede batendo neles."
 Message="O estado da fonte de energia dois do Campo de Força é ativo."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Aperte os botões vermelhos na parede batendo neles."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Você pegou 80 Fragmentos de Tarídio"

--- a/Unreal/SystemLocalized/rut/Dig.rut
+++ b/Unreal/SystemLocalized/rut/Dig.rut
@@ -75,3 +75,7 @@ Hint="Нажмите на красные кнопки на стене навал
 Message="Статус второго источника питания силового поля - активен."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Нажмите на красные кнопки на стене навалившись на них."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Вы взяли 80 кристаллов таридия"

--- a/Unreal/WIP/Template/Dig.template
+++ b/Unreal/WIP/Template/Dig.template
@@ -75,3 +75,7 @@ Hint=""
 Message=""
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint=""
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage=""

--- a/Unreal/WIP/WIP-FinishedFiles/czt/Dig.czt
+++ b/Unreal/WIP/WIP-FinishedFiles/czt/Dig.czt
@@ -75,3 +75,7 @@ Hint="Stiskni cervena tlacitka na zdi tim ze do nich vrazis."
 Message="Zalozni zdroj energie pro silove pole je zapnuty."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Stiskni cervena tlacitka na zdi tim ze do nich vrazis."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Sebral jsi 80 Tarydiovych Strepu"

--- a/Unreal/WIP/WIP-FinishedFiles/hut/Dig.hut
+++ b/Unreal/WIP/WIP-FinishedFiles/hut/Dig.hut
@@ -75,3 +75,7 @@ Hint="Nyomd meg a piros gombokat a falon úgy, hogy nekik mész."
 Message="Kettes Erötér energiaforrása aktív."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Nyomd meg a piros gombokat a falon úgy, hogy nekik mész."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Felvettél 80 Tarydium Szilánkot"

--- a/Unreal/WIP/WIP-FinishedFiles/jpt/Dig.jpt
+++ b/Unreal/WIP/WIP-FinishedFiles/jpt/Dig.jpt
@@ -75,3 +75,7 @@ Hint="壁にぶつかって赤いボタンを押します。"
 Message="フォースフィールド電源2のステータスがアクティブです。"
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="壁にぶつかって赤いボタンを押します。"
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="あなたは80のタリジウムの破片を拾いました"

--- a/Unreal/WIP/WIP-FinishedFiles/not/Dig.not
+++ b/Unreal/WIP/WIP-FinishedFiles/not/Dig.not
@@ -75,3 +75,7 @@ Hint="Trykk på de røde knappene på veggen ved å støte på dem."
 Message="Force Field strømkilde to status er aktiv."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Trykk på de røde knappene på veggen ved å støte på dem."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Du plukket opp 80 Tarydium-Skjær"

--- a/Unreal/WIP/WIP-FinishedFiles/svt/Dig.svt
+++ b/Unreal/WIP/WIP-FinishedFiles/svt/Dig.svt
@@ -74,3 +74,7 @@ Hint="Tryck på de röda knapparna på väggen genom att stöta på dem."
 Message="Force Field-strömkällans två status är aktiv."
 ; EN: Hint="Press the red buttons on the wall by bumping into them."
 Hint="Tryck på de röda knapparna på väggen genom att stöta på dem."
+
+[StingerAmmo17]
+; EN: PickupMessage="You picked up 80 Tarydium Shards"
+PickupMessage="Du plockade upp 80 Tarydium-skärvor"


### PR DESCRIPTION
There's a Stinger pickup that grants 80 units rather than the regular 40. This fix prints the appropriate message in all 15 languages.